### PR TITLE
Fix conflicts and serve plugin manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ Sistema de simulación y backtesting financiero con endpoints REST. Calcula ROI 
 pip install -r requirements.txt
 ```
 
+### Ejecutar servidor
+```bash
+bash start.sh
+```
+
 ### Ejecutar pruebas
 ```bash
 pytest -q
@@ -21,6 +26,11 @@ python src/simulator/simulate_market.py
 Accede al manifiesto:
 ```
 https://<tu-app>.railway.app/.well-known/ai-plugin.json
+```
+
+La documentación REST se expone en:
+```
+https://<tu-app>.railway.app/openapi.yaml
 ```
 
 Los endpoints disponibles se documentan en `openapi.yaml` e incluyen `/predict`, `/evaluate`, `/risk` y `/health`.

--- a/logs/logging.py
+++ b/logs/logging.py
@@ -1,9 +1,11 @@
 import json
+import os
 from datetime import datetime
 
 
 def log_decision(event: dict) -> None:
     """Append event with timestamp to narrative trace."""
     event["timestamp"] = datetime.utcnow().isoformat()
+    os.makedirs("logs", exist_ok=True)
     with open("logs/narrative_trace.jsonl", "a") as f:
         f.write(json.dumps(event) + "\n")

--- a/main.py
+++ b/main.py
@@ -1,10 +1,11 @@
 from fastapi import FastAPI
+from fastapi.responses import FileResponse
 from exo_fin_gpt.core.backtesting import run_backtest
 
 app = FastAPI()
 
 
-@app.get('/health')
+@app.get("/health")
 def health():
     return {'status': 'ok'}
 
@@ -30,3 +31,13 @@ def evaluate():
     except FileNotFoundError:
         content = 'No report available'
     return {'report': content}
+
+
+@app.get("/openapi.yaml", include_in_schema=False)
+def openapi_spec():
+    return FileResponse("openapi.yaml", media_type="text/yaml")
+
+
+@app.get("/.well-known/ai-plugin.json", include_in_schema=False)
+def plugin_manifest():
+    return FileResponse(".well-known/ai-plugin.json", media_type="application/json")

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,17 +1,17 @@
 openapi: 3.0.1
 info:
-  title: EXO-FIN-GPT
+  title: EXO-FIN-GPT API
   version: "1.0"
 paths:
   /predict:
     post:
-      summary: "Generar predicción reflexiva"
-  /risk:
-    get:
-      summary: "Consultar riesgo del portafolio"
+      summary: Ejecutar predicción ROI y Sharpe
   /evaluate:
     get:
-      summary: "Resultados del simulador"
+      summary: Mostrar resultados simulados
+  /risk:
+    get:
+      summary: Evaluar riesgo de inversión
   /health:
     get:
-      summary: "Estado del sistema"
+      summary: Verificar estado del sistema

--- a/src/simulator/simulate_market.py
+++ b/src/simulator/simulate_market.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from pathlib import Path
 
@@ -7,6 +8,9 @@ import numpy as np
 from exo_fin_gpt.core.backtesting import run_backtest
 from logs.logging import log_decision
 
+
+os.makedirs("logs", exist_ok=True)
+os.makedirs("reports", exist_ok=True)
 
 np.random.seed(42)
 prices = [100]

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -13,3 +13,8 @@ def test_health():
     r = client.get('/health')
     assert r.status_code == 200
     assert r.json() == {'status': 'ok'}
+
+
+def test_openapi():
+    r = client.get('/openapi.yaml')
+    assert r.status_code == 200


### PR DESCRIPTION
## Summary
- fix openapi spec and README instructions
- ensure logs directory is created before writing
- create reports/logs in simulator
- expose `/openapi.yaml` and plugin manifest from FastAPI app
- add tests for openapi endpoint

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `python src/simulator/simulate_market.py`

------
https://chatgpt.com/codex/tasks/task_e_686cd21722a0832cbe56cc56e5ec973e