### PR TITLE
Add ROI validation and /predict tests

### DIFF
--- a/exo_fin_gpt/core/backtesting.py
+++ b/exo_fin_gpt/core/backtesting.py
@@ -2,8 +2,10 @@ import numpy as np
 
 
 def run_backtest(prices):
-    """Calculate ROI and annualized Sharpe ratio for price series."""
+    """Calculate ROI and annualized Sharpe ratio for a price series."""
     returns = np.diff(prices) / prices[:-1]
-    roi = (prices[-1] - prices[0]) / prices[0]
+    roi = float((prices[-1] - prices[0]) / prices[0])
+    # Verify ROI is a valid positive float
+    assert isinstance(roi, float) and roi > 0, "Error: ROI inválido o nulo"
     sharpe = np.mean(returns) / np.std(returns) * np.sqrt(12)
     return {"roi": roi, "sharpe": sharpe}

--- a/main.py
+++ b/main.py
@@ -1,8 +1,15 @@
 from fastapi import FastAPI
 from fastapi.responses import FileResponse
+from pydantic import BaseModel
+
 from exo_fin_gpt.core.backtesting import run_backtest
+from logs.logging import log_decision
 
 app = FastAPI()
+
+
+class PriceSeries(BaseModel):
+    prices: list[float]
 
 
 @app.get("/health")
@@ -11,8 +18,9 @@ def health():
 
 
 @app.post('/predict')
-def predict(prices: list[float]):
-    metrics = run_backtest(prices)
+def predict(data: PriceSeries):
+    metrics = run_backtest(data.prices)
+    log_decision({"event": "predict", "prices": data.prices, "metrics": metrics})
     return metrics
 
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6,6 +6,9 @@ paths:
   /predict:
     post:
       summary: Ejecutar predicción ROI y Sharpe
+      responses:
+        '200':
+          description: Resultado exitoso de predicción
   /evaluate:
     get:
       summary: Mostrar resultados simulados

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -18,3 +18,11 @@ def test_health():
 def test_openapi():
     r = client.get('/openapi.yaml')
     assert r.status_code == 200
+
+
+def test_predict():
+    r = client.post('/predict', json={'prices': [100, 105, 110]})
+    assert r.status_code == 200
+    data = r.json()
+    assert 'roi' in data
+    assert data['roi'] > 0


### PR DESCRIPTION
## Summary
- enforce positive ROI in `run_backtest`
- add model and logging to `/predict` endpoint
- document `/predict` response in `openapi.yaml`
- test `/predict` returns ROI

## Testing
- `pytest -q`
- `python src/simulator/simulate_market.py`
- `bash start.sh` *(checked /health, /openapi.yaml, /ai-plugin.json)*

------
https://chatgpt.com/codex/tasks/task_e_687788cfc35c832ca83d09cca75e3271